### PR TITLE
fix: update DatedUserAchievement model to be an object

### DIFF
--- a/src/user/models/dated-user-achievement.model.ts
+++ b/src/user/models/dated-user-achievement.model.ts
@@ -14,4 +14,4 @@ export type DatedUserAchievement = {
   cumulScore: number;
   badgeUrl: string;
   gameUrl: string;
-}[];
+};


### PR DESCRIPTION
When calling `getAchievementsEarnedBetween()` and `getAchievementsEarnedOnDay()` the returned type is `Promise<DatedUserAchievement[]>`. 

`DatedUserAchievement` is defined as:
```
export type DatedUserAchievement = {
    date: string;
    hardcoreMode: boolean;
    achievementId: number;
    title: string;
    description: string;
    badgeName: string;
    points: number;
    author: string;
    gameTitle: string;
    gameIcon: string;
    gameId: number;
    consoleName: string;
    cumulScore: number;
    badgeUrl: string;
    gameUrl: string;
}[];
```

This means the promise would return an array of arrays. This PR updates `DatedUserAchievement` to be simply an object so it is consistent with what the API returns.