### PR TITLE
fix: add `type` prop to DatedUserAchievement model

### DIFF
--- a/src/user/getAchievementsEarnedBetween.test.ts
+++ b/src/user/getAchievementsEarnedBetween.test.ts
@@ -63,8 +63,7 @@ describe("Function: getAchievementsEarnedBetween", () => {
       toDate: new Date("2022-10-13")
     });
 
-    // ASSERT
-    expect(response).toEqual([
+    const expectedResponse: DatedUserAchievement[] = [
       {
         date: "2022-10-12 07:36:31",
         hardcoreMode: true,
@@ -83,6 +82,9 @@ describe("Function: getAchievementsEarnedBetween", () => {
         gameUrl: "/game/3571",
         type: "progression"
       }
-    ] as DatedUserAchievement[]);
+    ];
+
+    // ASSERT
+    expect(response).toEqual(expectedResponse);
   });
 });

--- a/src/user/getAchievementsEarnedBetween.test.ts
+++ b/src/user/getAchievementsEarnedBetween.test.ts
@@ -4,7 +4,10 @@ import { setupServer } from "msw/node";
 import { apiBaseUrl } from "../utils/internal";
 import { buildAuthorization } from "../utils/public";
 import { getAchievementsEarnedBetween } from "./getAchievementsEarnedBetween";
-import type { DatedUserAchievementsResponse } from "./models";
+import type {
+  DatedUserAchievement,
+  DatedUserAchievementsResponse
+} from "./models";
 
 const server = setupServer();
 
@@ -42,7 +45,8 @@ describe("Function: getAchievementsEarnedBetween", () => {
         ConsoleName: "PlayStation Portable",
         CumulScore: 40,
         BadgeURL: "/Badge/193797.png",
-        GameURL: "/game/3571"
+        GameURL: "/game/3571",
+        Type: "progression"
       }
     ];
 
@@ -76,8 +80,9 @@ describe("Function: getAchievementsEarnedBetween", () => {
         consoleName: "PlayStation Portable",
         cumulScore: 40,
         badgeUrl: "/Badge/193797.png",
-        gameUrl: "/game/3571"
+        gameUrl: "/game/3571",
+        type: "progression"
       }
-    ]);
+    ] as DatedUserAchievement[]);
   });
 });

--- a/src/user/getAchievementsEarnedBetween.ts
+++ b/src/user/getAchievementsEarnedBetween.ts
@@ -57,7 +57,8 @@ import type {
  *     consoleName: 'PlayStation Portable',
  *     cumulScore: 120,
  *     badgeUrl: '/Badge/193756.png',
- *     gameUrl: '/game/3571'
+ *     gameUrl: '/game/3571',
+ *     type: 'progression'
  *   }
  * ]
  * ```

--- a/src/user/getAchievementsEarnedOnDay.test.ts
+++ b/src/user/getAchievementsEarnedOnDay.test.ts
@@ -62,8 +62,7 @@ describe("Function: getAchievementsEarnedOnDay", () => {
       onDate: new Date("2022-10-12")
     });
 
-    // ASSERT
-    expect(response).toEqual([
+    const expectedResponse: DatedUserAchievement[] = [
       {
         date: "2022-10-12 07:36:31",
         hardcoreMode: true,
@@ -82,6 +81,9 @@ describe("Function: getAchievementsEarnedOnDay", () => {
         gameUrl: "/game/3571",
         type: null
       }
-    ] as DatedUserAchievement[]);
+    ];
+
+    // ASSERT
+    expect(response).toEqual(expectedResponse);
   });
 });

--- a/src/user/getAchievementsEarnedOnDay.test.ts
+++ b/src/user/getAchievementsEarnedOnDay.test.ts
@@ -4,7 +4,10 @@ import { setupServer } from "msw/node";
 import { apiBaseUrl } from "../utils/internal";
 import { buildAuthorization } from "../utils/public";
 import { getAchievementsEarnedOnDay } from "./getAchievementsEarnedOnDay";
-import type { DatedUserAchievementsResponse } from "./models";
+import type {
+  DatedUserAchievement,
+  DatedUserAchievementsResponse
+} from "./models";
 
 const server = setupServer();
 
@@ -42,7 +45,8 @@ describe("Function: getAchievementsEarnedOnDay", () => {
         ConsoleName: "PlayStation Portable",
         CumulScore: 40,
         BadgeURL: "/Badge/193797.png",
-        GameURL: "/game/3571"
+        GameURL: "/game/3571",
+        Type: null
       }
     ];
 
@@ -75,8 +79,9 @@ describe("Function: getAchievementsEarnedOnDay", () => {
         consoleName: "PlayStation Portable",
         cumulScore: 40,
         badgeUrl: "/Badge/193797.png",
-        gameUrl: "/game/3571"
+        gameUrl: "/game/3571",
+        type: null
       }
-    ]);
+    ] as DatedUserAchievement[]);
   });
 });

--- a/src/user/getAchievementsEarnedOnDay.ts
+++ b/src/user/getAchievementsEarnedOnDay.ts
@@ -56,7 +56,8 @@ import type {
  *      consoleName: 'PlayStation Portable',
  *      cumulScore: 120,
  *      badgeUrl: '/Badge/193756.png',
- *      gameUrl: '/game/3571'
+ *      gameUrl: '/game/3571',
+ *      type: 'progression'
  *    }
  *  ]
  * ```

--- a/src/user/models/dated-user-achievement.model.ts
+++ b/src/user/models/dated-user-achievement.model.ts
@@ -14,4 +14,5 @@ export type DatedUserAchievement = {
   cumulScore: number;
   badgeUrl: string;
   gameUrl: string;
+  type: "progression" | "win_condition" | "missable" | null;
 };

--- a/src/user/models/dated-user-achievements-response.model.ts
+++ b/src/user/models/dated-user-achievements-response.model.ts
@@ -14,6 +14,7 @@ interface DatedUserAchievementResponseEntity {
   CumulScore: number;
   BadgeURL: string;
   GameURL: string;
+  Type: "progression" | "win_condition" | "missable" | null;
 }
 
 export type DatedUserAchievementsResponse =


### PR DESCRIPTION
Add the `type` property to `DatedUserAchievement` and updated unit tests.

Have it set as such to match what I saw in RAWeb [here](https://github.com/RetroAchievements/RAWeb/blob/master/public/API/API_GetAchievementsEarnedBetween.php)
```
type: "progression" | "win_condition" | "missable" | null;
```