### PR TITLE
fix: don't cast `released` to number in `getGameInfoAndUserProgress()`

### DIFF
--- a/src/user/getGameInfoAndUserProgress.test.ts
+++ b/src/user/getGameInfoAndUserProgress.test.ts
@@ -99,7 +99,7 @@ describe("Function: getGameInfoAndUserProgress", () => {
       publisher: "Activision ",
       developer: "David Crane",
       genre: "Racing",
-      released: 1980,
+      released: "1980",
       isFinal: false,
       consoleName: "Atari 2600",
       richPresencePatch: "2b92fa1bf9635c303b3b7f8feea3ed3c",

--- a/src/user/getGameInfoAndUserProgress.ts
+++ b/src/user/getGameInfoAndUserProgress.ts
@@ -51,7 +51,7 @@ import type {
  *   publisher: "Activision",
  *   developer: "David Crane",
  *   genre: "Racing",
- *   released: 1980,
+ *   released: "1980",
  *   isFinal: false,
  *   consoleName: "Atari 2600",
  *   richPresencePatch: "2b92fa1bf9635c303b3b7f8feea3ed3c",
@@ -113,7 +113,6 @@ export const getGameInfoAndUserProgress = async (
       "DisplayOrder",
       "NumDistinctPlayersCasual",
       "NumDistinctPlayersHardcore",
-      "Released",
     ],
   });
 };


### PR DESCRIPTION
Same issue as https://github.com/RetroAchievements/api-js/issues/61