### PR TITLE
fix: ts comparison

### DIFF
--- a/src/__playground.ts
+++ b/src/__playground.ts
@@ -17,8 +17,8 @@
 import { buildAuthorization, getAchievementCount } from "./index";
 
 // MODIFY THESE VALUES.
-const username = "myUsername";
-const webApiKey = "myWebApiKey";
+const username: string = "";
+const webApiKey: string = "";
 
 const main = async () => {
   console.log("🚀  @retroachievements/api playground is running.\n");


### PR DESCRIPTION
This fixes the following typescript warnings that pop up when you change the values of `username` and `webApiKey` from their defaults.

```
This comparison appears to be unintentional because the types '""' and '"myUsername"' have no overlap.
```

```
This comparison appears to be unintentional because the types '""' and '"myWebApiKey"' have no overlap.
```