### PR TITLE
refactor: simplify authorization API

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,29 +45,20 @@ Learn how to authenticate and start pulling data from RetroAchievements on our d
 
 To use any endpoint function in the API, you must first be authorized by RetroAchievements. Fortunately, this is a fairly straightforward process.
 
-1. Visit [your control panel](https://retroachievements.org/controlpanel.php) on the RA website.
+1. Visit [settings page](https://retroachievements.org/settings) on the RA website.
 
 2. Find the "Keys" section on the page. Copy the web API key value. **Do not expose your API key anywhere publicly.**
 
-3. You can now create your authorization object using your web API key.
-
-```ts
-import { buildAuthorization } from "@retroachievements/api";
-
-const username = "<your username on RA>";
-const webApiKey = "<your web API key>";
-
-const authorization = buildAuthorization({ username, webApiKey });
-```
-
-4. You now have all you need to use any function in the API. Each function takes this authorization object as its first argument. Here's an example:
+3. You now have all you need to use any function from the API. Each function takes this web API key as its first argument. Here's an example:
 
 ```ts
 import { getGame } from "@retroachievements/api";
 
+const webApiKey = "<your web API key>";
+
 // This returns basic metadata about the game on this page:
 // https://retroachievements.org/game/14402
-const game = await getGame(authorization, { gameId: 14402 });
+const game = await getGame(webApiKey, { gameId: 14402 });
 ```
 
 ## API

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "format:check": "prettier --check . '**/*.{json,md,js,ts,tsx}'",
     "lint": "eslint --ignore-path .gitignore --ext .js,.ts,.tsx .",
     "lint:fix": "eslint --ignore-path .gitignore --ext .js,.ts,.tsx . --fix",
-    "test": "vitest run",
+    "test": "vitest run --reporter=dot",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
     "verify": "pnpm format:check && pnpm lint && pnpm test:coverage && pnpm build",

--- a/src/achievement/getAchievementUnlocks.ts
+++ b/src/achievement/getAchievementUnlocks.ts
@@ -5,7 +5,7 @@ import {
   call,
   serializeProperties,
 } from "../utils/internal";
-import type { AuthObject } from "../utils/public";
+import type { ApiAuthorization } from "../utils/public";
 import type {
   AchievementUnlocksMetadata,
   GetAchievementUnlocksResponse,
@@ -15,8 +15,7 @@ import type {
  * A call to this function will retrieve a list of users who
  * have earned a given achievement, targeted by the achievement's ID.
  *
- * @param authorization An object containing your username and webApiKey.
- * This can be constructed with `buildAuthorization()`.
+ * @param authorization Your web API key retrieved from retroachievements.org/settings.
  *
  * @param payload.achievementId The target achievement we want to
  * retrieve the unlocks list for. If unknown, this can be found
@@ -31,7 +30,7 @@ import type {
  * @example
  * ```
  * const achievementUnlocks = await getAchievementUnlocks(
- *   authorization,
+ *   webApiKey,
  *   { achievementId: 13876 }
  * );
  * ```
@@ -50,7 +49,7 @@ import type {
  * ```
  */
 export const getAchievementUnlocks = async (
-  authorization: AuthObject,
+  authorization: ApiAuthorization,
   payload: { achievementId: ID; offset?: number; count?: number }
 ): Promise<AchievementUnlocksMetadata> => {
   const { achievementId, offset, count } = payload;

--- a/src/console/getConsoleIds.ts
+++ b/src/console/getConsoleIds.ts
@@ -4,7 +4,7 @@ import {
   call,
   serializeProperties,
 } from "../utils/internal";
-import type { AuthObject } from "../utils/public";
+import type { ApiAuthorization } from "../utils/public";
 import type { FetchedSystem, GetConsoleIdsResponse } from "./models";
 
 /**
@@ -12,8 +12,7 @@ import type { FetchedSystem, GetConsoleIdsResponse } from "./models";
  * of console ID and name pairs on the RetroAchievements.org
  * platform.
  *
- * @param authorization An object containing your username and webApiKey.
- * This can be constructed with `buildAuthorization()`.
+ * @param authorization Your web API key retrieved from retroachievements.org/settings.
  *
  * @param payload.shouldOnlyRetrieveActiveSystems If true, only systems that
  * officially support achievements will be returned.
@@ -39,7 +38,7 @@ import type { FetchedSystem, GetConsoleIdsResponse } from "./models";
  * ```
  */
 export const getConsoleIds = async (
-  authorization: AuthObject,
+  authorization: ApiAuthorization,
   payload?: {
     shouldOnlyRetrieveActiveSystems: boolean;
     shouldOnlyRetrieveGameSystems: boolean;

--- a/src/console/getGameList.ts
+++ b/src/console/getGameList.ts
@@ -5,15 +5,14 @@ import {
   call,
   serializeProperties,
 } from "../utils/internal";
-import type { AuthObject } from "../utils/public";
+import type { ApiAuthorization } from "../utils/public";
 import type { GameList, GetGameListResponse } from "./models";
 /**
  * A call to this function will retrieve the complete list
  * of games for a specified console on the RetroAchievements.org
  * platform.
  *
- * @param authorization An object containing your username and webApiKey.
- * This can be constructed with `buildAuthorization()`.
+ * @param authorization Your web API key retrieved from retroachievements.org/settings.
  *
  * @param payload.consoleId The unique console ID to retrieve a list of
  * games from. The list of consoleIds can be retrieved using the `getConsoleIds()`
@@ -53,7 +52,7 @@ import type { GameList, GetGameListResponse } from "./models";
  * ```
  */
 export const getGameList = async (
-  authorization: AuthObject,
+  authorization: ApiAuthorization,
   payload: {
     consoleId: ID;
     shouldOnlyRetrieveGamesWithAchievements?: boolean;

--- a/src/feed/getAchievementOfTheWeek.ts
+++ b/src/feed/getAchievementOfTheWeek.ts
@@ -4,7 +4,7 @@ import {
   call,
   serializeProperties,
 } from "../utils/internal";
-import type { AuthObject } from "../utils/public";
+import type { ApiAuthorization } from "../utils/public";
 import type {
   AchievementOfTheWeek,
   GetAchievementOfTheWeekResponse,
@@ -14,8 +14,7 @@ import type {
  * A call to this function will retrieve comprehensive
  * metadata about the current Achievement of the Week.
  *
- * @param authorization An object containing your username and webApiKey.
- * This can be constructed with `buildAuthorization()`.
+ * @param authorization Your web API key retrieved from retroachievements.org/settings.
  *
  * @example
  * ```
@@ -59,7 +58,7 @@ import type {
  * ```
  */
 export const getAchievementOfTheWeek = async (
-  authorization: AuthObject
+  authorization: ApiAuthorization
 ): Promise<AchievementOfTheWeek> => {
   const url = buildRequestUrl(
     apiBaseUrl,

--- a/src/feed/getActiveClaims.ts
+++ b/src/feed/getActiveClaims.ts
@@ -4,15 +4,14 @@ import {
   call,
   serializeProperties,
 } from "../utils/internal";
-import type { AuthObject } from "../utils/public";
+import type { ApiAuthorization } from "../utils/public";
 import type { GetSetClaimsResponse, SetClaim } from "./models";
 
 /**
  * A call to this function returns information about all
  * (1000 max) active set claims.
  *
- * @param authorization An object containing your username and webApiKey.
- * This can be constructed with `buildAuthorization()`.
+ * @param authorization Your web API key retrieved from retroachievements.org/settings.
  *
  * @example
  * ```
@@ -45,7 +44,7 @@ import type { GetSetClaimsResponse, SetClaim } from "./models";
  * ```
  */
 export const getActiveClaims = async (
-  authorization: AuthObject
+  authorization: ApiAuthorization
 ): Promise<SetClaim[]> => {
   const url = buildRequestUrl(
     apiBaseUrl,

--- a/src/feed/getClaims.ts
+++ b/src/feed/getClaims.ts
@@ -4,13 +4,30 @@ import {
   call,
   serializeProperties,
 } from "../utils/internal";
-import type { AuthObject } from "../utils/public";
+import type { ApiAuthorization } from "../utils/public";
 import type { GetSetClaimsResponse, SetClaim } from "./models";
 
 type ClaimKind = "completed" | "dropped" | "expired";
 
+/**
+ * A call to this function will retrieve a list of achievement set claims.
+ *
+ * @param authorization Your web API key retrieved from retroachievements.org/settings.
+ *
+ * @param payload.claimKind The specific kind of claims you'd like to retrieve a list of.
+ *
+ * @example
+ * ```
+ * const claims = await getClaims(
+ *   authorization,
+ *   { claimKind: "completed" }
+ * );
+ * ```
+ *
+ * @returns An array containing all the specified claims.
+ */
 export const getClaims = async (
-  authorization: AuthObject,
+  authorization: ApiAuthorization,
   payload: { claimKind: ClaimKind }
 ): Promise<SetClaim[]> => {
   const { claimKind } = payload;

--- a/src/feed/getRecentGameAwards.ts
+++ b/src/feed/getRecentGameAwards.ts
@@ -4,15 +4,14 @@ import {
   call,
   serializeProperties,
 } from "../utils/internal";
-import type { AuthObject, AwardKind } from "../utils/public";
+import type { ApiAuthorization, AwardKind } from "../utils/public";
 import type { GetRecentGameAwardsResponse, RecentGameAwards } from "./models";
 
 /**
  * A call to this function will retrieve all recently granted game
  * awards across the site's userbase.
  *
- * @param authorization An object containing your username and webApiKey.
- * This can be constructed with `buildAuthorization()`.
+ * @param authorization Your web API key retrieved from retroachievements.org/settings.
  *
  * @param payload.startDate The date to fetch awards from.
  *
@@ -50,7 +49,7 @@ import type { GetRecentGameAwardsResponse, RecentGameAwards } from "./models";
  * ```
  */
 export const getRecentGameAwards = async (
-  authorization: AuthObject,
+  authorization: ApiAuthorization,
   payload?: Partial<{
     startDate: string;
     offset: number;

--- a/src/feed/getTopTenUsers.ts
+++ b/src/feed/getTopTenUsers.ts
@@ -1,5 +1,5 @@
 import { apiBaseUrl, buildRequestUrl, call } from "../utils/internal";
-import type { AuthObject } from "../utils/public";
+import type { ApiAuthorization } from "../utils/public";
 import type {
   GetTopTenUsersResponse,
   TopTenUsers,
@@ -10,8 +10,7 @@ import type {
  * A call to this function will retrieve the current top ten users
  * on the site.
  *
- * @param authorization An object containing your username and webApiKey.
- * This can be constructed with `buildAuthorization()`.
+ * @param authorization Your web API key retrieved from retroachievements.org/settings.
  *
  * @example
  * ```
@@ -28,7 +27,7 @@ import type {
  * ```
  */
 export const getTopTenUsers = async (
-  authorization: AuthObject
+  authorization: ApiAuthorization
 ): Promise<TopTenUsers> => {
   const url = buildRequestUrl(
     apiBaseUrl,

--- a/src/game/getAchievementCount.ts
+++ b/src/game/getAchievementCount.ts
@@ -5,15 +5,14 @@ import {
   call,
   serializeProperties,
 } from "../utils/internal";
-import type { AuthObject } from "../utils/public";
+import type { ApiAuthorization } from "../utils/public";
 import type { AchievementCount, GetAchievementCountResponse } from "./models";
 
 /**
  * A call to this function will retrieve the list of
  * achievement IDs for a game, targeted by game ID.
  *
- * @param authorization An object containing your username and webApiKey.
- * This can be constructed with `buildAuthorization()`.
+ * @param authorization Your web API key retrieved from retroachievements.org/settings.
  *
  * @param payload.gameId The unique game ID. If you are unsure, open the
  * game's page on the RetroAchievements.org website. For example, Dragster's
@@ -35,7 +34,7 @@ import type { AchievementCount, GetAchievementCountResponse } from "./models";
  * ```
  */
 export const getAchievementCount = async (
-  authorization: AuthObject,
+  authorization: ApiAuthorization,
   payload: { gameId: ID }
 ): Promise<AchievementCount> => {
   const { gameId } = payload;

--- a/src/game/getAchievementDistribution.ts
+++ b/src/game/getAchievementDistribution.ts
@@ -1,6 +1,6 @@
 import type { ID } from "../utils/internal";
 import { apiBaseUrl, buildRequestUrl, call } from "../utils/internal";
-import type { AuthObject } from "../utils/public";
+import type { ApiAuthorization } from "../utils/public";
 import type {
   AchievementDistributionFlags,
   GetAchievementDistributionResponse,
@@ -11,8 +11,7 @@ import type {
  * of the number of players who have earned a specific
  * number of achievements for a given game ID.
  *
- * @param authorization An object containing your username and webApiKey.
- * This can be constructed with `buildAuthorization()`.
+ * @param authorization Your web API key retrieved from retroachievements.org/settings.
  *
  * @param payload.gameId The unique game ID. If you are unsure, open the
  * game's page on the RetroAchievements.org website. For example, Dragster's
@@ -57,7 +56,7 @@ import type {
  * ```
  */
 export const getAchievementDistribution = async (
-  authorization: AuthObject,
+  authorization: ApiAuthorization,
   payload: {
     gameId: ID;
     flags?: AchievementDistributionFlags;

--- a/src/game/getGame.ts
+++ b/src/game/getGame.ts
@@ -5,15 +5,14 @@ import {
   call,
   serializeProperties,
 } from "../utils/internal";
-import type { AuthObject } from "../utils/public";
+import type { ApiAuthorization } from "../utils/public";
 import type { Game, GetGameResponse } from "./models";
 
 /**
  * A call to this function will retrieve basic metadata about
  * a game, targeted via its unique ID.
  *
- * @param authorization An object containing your username and webApiKey.
- * This can be constructed with `buildAuthorization()`.
+ * @param authorization Your web API key retrieved from retroachievements.org/settings.
  *
  * @param payload.gameId The unique game ID. If you are unsure, open the
  * game's page on the RetroAchievements.org website. For example, Dragster's
@@ -52,7 +51,7 @@ import type { Game, GetGameResponse } from "./models";
  * ```
  */
 export const getGame = async (
-  authorization: AuthObject,
+  authorization: ApiAuthorization,
   payload: { gameId: ID }
 ): Promise<Game> => {
   const { gameId } = payload;

--- a/src/game/getGameExtended.ts
+++ b/src/game/getGameExtended.ts
@@ -5,15 +5,14 @@ import {
   call,
   serializeProperties,
 } from "../utils/internal";
-import type { AuthObject } from "../utils/public";
+import type { ApiAuthorization } from "../utils/public";
 import type { GameExtended, GetGameExtendedResponse } from "./models";
 
 /**
  * A call to this function will retrieve extended metadata
  * about a game, targeted via its unique ID.
  *
- * @param authorization An object containing your username and webApiKey.
- * This can be constructed with `buildAuthorization()`.
+ * @param authorization Your web API key retrieved from retroachievements.org/settings.
  *
  * @param payload.gameId The unique game ID. If you are unsure, open the
  * game's page on the RetroAchievements.org website. For example, Dragster's
@@ -72,7 +71,7 @@ import type { GameExtended, GetGameExtendedResponse } from "./models";
  * ```
  */
 export const getGameExtended = async (
-  authorization: AuthObject,
+  authorization: ApiAuthorization,
   payload: { gameId: ID; isRequestingUnofficialAchievements?: boolean }
 ): Promise<GameExtended> => {
   const { gameId, isRequestingUnofficialAchievements } = payload;

--- a/src/game/getGameRankAndScore.ts
+++ b/src/game/getGameRankAndScore.ts
@@ -5,7 +5,7 @@ import {
   call,
   serializeProperties,
 } from "../utils/internal";
-import type { AuthObject } from "../utils/public";
+import type { ApiAuthorization } from "../utils/public";
 import type {
   GameRankAndScoreEntity,
   GetGameRankAndScoreResponse,
@@ -17,8 +17,7 @@ import type {
  * points earners for a game. The game is targeted via
  * its unique ID.
  *
- * @param authorization An object containing your username and webApiKey.
- * This can be constructed with `buildAuthorization()`.
+ * @param authorization Your web API key retrieved from retroachievements.org/settings.
  *
  * @param payload.gameId The unique game ID. If you are unsure, open the
  * game's page on the RetroAchievements.org website. For example, Dragster's
@@ -44,7 +43,7 @@ import type {
  * ```
  */
 export const getGameRankAndScore = async (
-  authorization: AuthObject,
+  authorization: ApiAuthorization,
   payload: { gameId: ID; type: "latest-masters" | "high-scores" }
 ): Promise<GameRankAndScoreEntity[]> => {
   const { gameId, type } = payload;

--- a/src/game/getGameRating.ts
+++ b/src/game/getGameRating.ts
@@ -5,15 +5,14 @@ import {
   call,
   serializeProperties,
 } from "../utils/internal";
-import type { AuthObject } from "../utils/public";
+import type { ApiAuthorization } from "../utils/public";
 import type { GameRating, GetGameRatingResponse } from "./models";
 
 /**
  * A call to this function will retrieve metadata about
  * how users have rated the game and its set.
  *
- * @param authorization An object containing your username and webApiKey.
- * This can be constructed with `buildAuthorization()`.
+ * @param authorization Your web API key retrieved from retroachievements.org/settings.
  *
  * @param payload.gameId The unique game ID. If you are unsure, open the
  * game's page on the RetroAchievements.org website. For example, Dragster's
@@ -42,7 +41,7 @@ import type { GameRating, GetGameRatingResponse } from "./models";
  * ```
  */
 export const getGameRating = async (
-  authorization: AuthObject,
+  authorization: ApiAuthorization,
   payload: { gameId: ID }
 ): Promise<GameRating> => {
   const { gameId } = payload;

--- a/src/ticket/getTicketData.ts
+++ b/src/ticket/getTicketData.ts
@@ -5,7 +5,7 @@ import {
   call,
   serializeProperties,
 } from "../utils/internal";
-import type { AuthObject } from "../utils/public";
+import type { ApiAuthorization } from "../utils/public";
 import type {
   AchievementTicketStats,
   GameTicketStats,
@@ -51,7 +51,7 @@ interface GetTicketDataAllPayloadValues {
  * @returns An object containing metadata about a target ticket.
  */
 export function getTicketData(
-  authorization: AuthObject,
+  authorization: ApiAuthorization,
   payload: { ticketId: ID }
 ): Promise<TicketEntity>;
 
@@ -76,7 +76,7 @@ export function getTicketData(
  * @returns A list of the most recently opened tickets on the site.
  */
 export function getTicketData(
-  authorization: AuthObject,
+  authorization: ApiAuthorization,
   payload?: Partial<{ offset: number; count: number }>
 ): Promise<RecentTickets>;
 
@@ -104,7 +104,7 @@ export function getTicketData(
  * @returns A list of the most recently opened tickets on the site.
  */
 export function getTicketData(
-  authorization: AuthObject,
+  authorization: ApiAuthorization,
   payload: { isGettingMostTicketedGames: true; offset?: number; count?: number }
 ): Promise<MostTicketedGames>;
 
@@ -129,7 +129,7 @@ export function getTicketData(
  * @returns An achievement developer's ticket stats.
  */
 export function getTicketData(
-  authorization: AuthObject,
+  authorization: ApiAuthorization,
   payload: { username: string }
 ): Promise<UserTicketStats>;
 
@@ -160,7 +160,7 @@ export function getTicketData(
  * @returns A game's ticket stats, potentially also including the ticket list.
  */
 export function getTicketData(
-  authorization: AuthObject,
+  authorization: ApiAuthorization,
   payload: {
     gameId: ID;
     isGettingTicketsForUnofficialAchievements?: true;
@@ -174,8 +174,7 @@ export function getTicketData(
  * of an achievement's ID, open its page on the RetroAchievements
  * website and copy the number at the end of the URL.
  *
- * @param authorization An object containing your username and webApiKey.
- * This can be constructed with `buildAuthorization()`.
+ * @param authorization Your web API key retrieved from retroachievements.org/settings.
  *
  * @param payload.achievementId The ID of the achievement to fetch ticket
  * stats for.
@@ -191,7 +190,7 @@ export function getTicketData(
  * @returns An achievement developer's ticket stats.
  */
 export function getTicketData(
-  authorization: AuthObject,
+  authorization: ApiAuthorization,
   payload: { achievementId: ID }
 ): Promise<AchievementTicketStats>;
 
@@ -200,7 +199,7 @@ export function getTicketData(
  */
 
 export async function getTicketData(
-  authorization: AuthObject,
+  authorization: ApiAuthorization,
   payload: GetTicketDataAllPayloadValues = {}
 ) {
   const queryParams = buildGetTicketDataQueryParams(payload);

--- a/src/user/getAchievementsEarnedBetween.ts
+++ b/src/user/getAchievementsEarnedBetween.ts
@@ -4,7 +4,7 @@ import {
   call,
   serializeProperties,
 } from "../utils/internal";
-import type { AuthObject } from "../utils/public";
+import type { ApiAuthorization } from "../utils/public";
 import type {
   DatedUserAchievement,
   DatedUserAchievementsResponse,
@@ -14,8 +14,7 @@ import type {
  * A call to this function will retrieve a list of achievements
  * earned by a given user between two provided dates.
  *
- * @param authorization An object containing your username and webApiKey.
- * This can be constructed with `buildAuthorization()`.
+ * @param authorization Your web API key retrieved from retroachievements.org/settings.
  *
  * @param payload.username The user for which to retrieve the
  * list of achievements for.
@@ -64,7 +63,7 @@ import type {
  * ```
  */
 export const getAchievementsEarnedBetween = async (
-  authorization: AuthObject,
+  authorization: ApiAuthorization,
   payload: { username: string; fromDate: Date; toDate: Date }
 ): Promise<DatedUserAchievement[]> => {
   const { username, fromDate, toDate } = payload;

--- a/src/user/getAchievementsEarnedOnDay.ts
+++ b/src/user/getAchievementsEarnedOnDay.ts
@@ -4,7 +4,7 @@ import {
   call,
   serializeProperties,
 } from "../utils/internal";
-import type { AuthObject } from "../utils/public";
+import type { ApiAuthorization } from "../utils/public";
 import type {
   DatedUserAchievement,
   DatedUserAchievementsResponse,
@@ -14,8 +14,7 @@ import type {
  * A call to this function will retrieve a list of achievements
  * earned by a given user on a specified date.
  *
- * @param authorization An object containing your username and webApiKey.
- * This can be constructed with `buildAuthorization()`.
+ * @param authorization Your web API key retrieved from retroachievements.org/settings.
  *
  * @param payload.username The user for which to retrieve the
  * list of achievements for.
@@ -63,7 +62,7 @@ import type {
  * ```
  */
 export const getAchievementsEarnedOnDay = async (
-  authorization: AuthObject,
+  authorization: ApiAuthorization,
   payload: { username: string; onDate: Date }
 ): Promise<DatedUserAchievement[]> => {
   const { username, onDate } = payload;

--- a/src/user/getGameInfoAndUserProgress.ts
+++ b/src/user/getGameInfoAndUserProgress.ts
@@ -5,7 +5,7 @@ import {
   call,
   serializeProperties,
 } from "../utils/internal";
-import type { AuthObject } from "../utils/public";
+import type { ApiAuthorization } from "../utils/public";
 import type {
   GameInfoAndUserProgress,
   GetGameInfoAndUserProgressResponse,
@@ -16,8 +16,7 @@ import type {
  * about a game, in addition to a user's progress about a game.
  * This is targeted via a game's unique ID and a given username.
  *
- * @param authorization An object containing your username and webApiKey.
- * This can be constructed with `buildAuthorization()`.
+ * @param authorization Your web API key retrieved from retroachievements.org/settings.
  *
  * @param payload.gameId The unique game ID. If you are unsure, open the
  * game's page on the RetroAchievements.org website. For example, Dragster's
@@ -89,7 +88,7 @@ import type {
  * ```
  */
 export const getGameInfoAndUserProgress = async (
-  authorization: AuthObject,
+  authorization: ApiAuthorization,
   payload: {
     gameId: ID;
     username: string;

--- a/src/user/getUserAwards.ts
+++ b/src/user/getUserAwards.ts
@@ -4,15 +4,14 @@ import {
   call,
   serializeProperties,
 } from "../utils/internal";
-import type { AuthObject } from "../utils/public";
+import type { ApiAuthorization } from "../utils/public";
 import type { GetUserAwardsResponse, UserAwards } from "./models";
 
 /**
  * A call to this function will retrieve metadata about the target user's
  * site awards, via their username.
  *
- * @param authorization An object containing your username and webApiKey.
- * This can be constructed with `buildAuthorization()`.
+ * @param authorization Your web API key retrieved from retroachievements.org/settings.
  *
  * @param payload.username The user for which to retrieve the site awards for.
  *
@@ -52,7 +51,7 @@ import type { GetUserAwardsResponse, UserAwards } from "./models";
  * ```
  */
 export const getUserAwards = async (
-  authorization: AuthObject,
+  authorization: ApiAuthorization,
   payload: { username: string }
 ): Promise<UserAwards> => {
   const { username } = payload;

--- a/src/user/getUserClaims.ts
+++ b/src/user/getUserClaims.ts
@@ -4,7 +4,7 @@ import {
   call,
   serializeProperties,
 } from "../utils/internal";
-import type { AuthObject } from "../utils/public";
+import type { ApiAuthorization } from "../utils/public";
 import type { GetUserClaimsResponse, UserClaims } from "./models";
 
 /**
@@ -12,8 +12,7 @@ import type { GetUserClaimsResponse, UserClaims } from "./models";
  * achievement set claims made over the lifetime of a given
  * user, targeted by their username.
  *
- * @param authorization An object containing your username and webApiKey.
- * This can be constructed with `buildAuthorization()`.
+ * @param authorization Your web API key retrieved from retroachievements.org/settings.
  *
  * @param payload.username The user for which to retrieve the historical
  * achievement set claims list for.
@@ -30,7 +29,7 @@ import type { GetUserClaimsResponse, UserClaims } from "./models";
  * made over the lifetime of the given user.
  */
 export const getUserClaims = async (
-  authorization: AuthObject,
+  authorization: ApiAuthorization,
   payload: { username: string }
 ): Promise<UserClaims> => {
   const { username } = payload;

--- a/src/user/getUserCompletedGames.ts
+++ b/src/user/getUserCompletedGames.ts
@@ -4,7 +4,7 @@ import {
   call,
   serializeProperties,
 } from "../utils/internal";
-import type { AuthObject } from "../utils/public";
+import type { ApiAuthorization } from "../utils/public";
 import type {
   GetUserCompletedGamesResponse,
   UserCompletedGames,
@@ -17,8 +17,7 @@ import type {
  * one for the hardcore completion. These are designated by
  * the `hardcoreMode` property on each completion object.
  *
- * @param authorization An object containing your username and webApiKey.
- * This can be constructed with `buildAuthorization()`.
+ * @param authorization Your web API key retrieved from retroachievements.org/settings.
  *
  * @param payload.username The user for which to retrieve the
  * completion metadata for.
@@ -62,7 +61,7 @@ import type {
  * ```
  */
 export const getUserCompletedGames = async (
-  authorization: AuthObject,
+  authorization: ApiAuthorization,
   payload: { username: string }
 ): Promise<UserCompletedGames> => {
   const { username } = payload;

--- a/src/user/getUserCompletionProgress.ts
+++ b/src/user/getUserCompletionProgress.ts
@@ -4,7 +4,7 @@ import {
   call,
   serializeProperties,
 } from "../utils/internal";
-import type { AuthObject } from "../utils/public";
+import type { ApiAuthorization } from "../utils/public";
 import type {
   GetUserCompletionProgressResponse,
   UserCompletionProgress,
@@ -14,8 +14,7 @@ import type {
  * A call to this function will retrieve a given user's completion
  * progress, targeted by their username.
  *
- * @param authorization An object containing your username and webApiKey.
- * This can be constructed with `buildAuthorization()`.
+ * @param authorization Your web API key retrieved from retroachievements.org/settings.
  *
  * @param payload.username The user for which to retrieve the progress for.
  *
@@ -55,7 +54,7 @@ import type {
  * ```
  */
 export const getUserCompletionProgress = async (
-  authorization: AuthObject,
+  authorization: ApiAuthorization,
   payload: { username: string; offset?: number; count?: number }
 ): Promise<UserCompletionProgress> => {
   const { username, offset, count } = payload;

--- a/src/user/getUserGameRankAndScore.ts
+++ b/src/user/getUserGameRankAndScore.ts
@@ -5,7 +5,7 @@ import {
   call,
   serializeProperties,
 } from "../utils/internal";
-import type { AuthObject } from "../utils/public";
+import type { ApiAuthorization } from "../utils/public";
 import type {
   GetUserGameRankAndScoreResponse,
   UserGameRankAndScore,
@@ -16,8 +16,7 @@ import type {
  * how a particular user has performed/ranked on a particular
  * game, targeted by game ID.
  *
- * @param authorization An object containing your username and webApiKey.
- * This can be constructed with `buildAuthorization()`.
+ * @param authorization Your web API key retrieved from retroachievements.org/settings.
  *
  * @param payload.gameId The unique game ID. If you are unsure, open the
  * game's page on the RetroAchievements.org website. For example, Dragster's
@@ -50,7 +49,7 @@ import type {
  * ```
  */
 export const getUserGameRankAndScore = async (
-  authorization: AuthObject,
+  authorization: ApiAuthorization,
   payload: { gameId: ID; username: string }
 ): Promise<UserGameRankAndScore> => {
   const { gameId, username } = payload;

--- a/src/user/getUserPoints.ts
+++ b/src/user/getUserPoints.ts
@@ -4,15 +4,14 @@ import {
   call,
   serializeProperties,
 } from "../utils/internal";
-import type { AuthObject } from "../utils/public";
+import type { ApiAuthorization } from "../utils/public";
 import type { GetUserPointsResponse, UserPoints } from "./models";
 
 /**
  * A call to this function will retrieve a given user's hardcore
  * and softcore points.
  *
- * @param authorization An object containing your username and webApiKey.
- * This can be constructed with `buildAuthorization()`.
+ * @param authorization Your web API key retrieved from retroachievements.org/settings.
  *
  * @param payload.username The user for which to retrieve the point totals for.
  *
@@ -33,7 +32,7 @@ import type { GetUserPointsResponse, UserPoints } from "./models";
  * ```
  */
 export const getUserPoints = async (
-  authorization: AuthObject,
+  authorization: ApiAuthorization,
   payload: { username: string }
 ): Promise<UserPoints> => {
   const { username } = payload;

--- a/src/user/getUserProfile.ts
+++ b/src/user/getUserProfile.ts
@@ -4,15 +4,14 @@ import {
   call,
   serializeProperties,
 } from "../utils/internal";
-import type { AuthObject } from "../utils/public";
+import type { ApiAuthorization } from "../utils/public";
 import type { GetUserProfileResponse, UserProfile } from "./models";
 
 /**
  * A call to this function will retrieve summary information about
  * a given user, targeted by username.
  *
- * @param authorization An object containing your username and webApiKey.
- * This can be constructed with `buildAuthorization()`.
+ * @param authorization Your web API key retrieved from retroachievements.org/settings.
  *
  * @param payload.username The user for which to retrieve the summary for.
  *
@@ -27,7 +26,7 @@ import type { GetUserProfileResponse, UserProfile } from "./models";
  * @returns An object containing profile summary metadata about a target user.
  */
 export const getUserProfile = async (
-  authorization: AuthObject,
+  authorization: ApiAuthorization,
   payload: {
     username: string;
   }

--- a/src/user/getUserProgress.ts
+++ b/src/user/getUserProgress.ts
@@ -5,15 +5,14 @@ import {
   call,
   serializeProperties,
 } from "../utils/internal";
-import type { AuthObject } from "../utils/public";
+import type { ApiAuthorization } from "../utils/public";
 import type { GetUserProgressResponse, UserProgress } from "./models";
 
 /**
  * A call to this function will retrieve a given user's
  * progress on a given list of games, targeted by game ID.
  *
- * @param authorization An object containing your username and webApiKey.
- * This can be constructed with `buildAuthorization()`.
+ * @param authorization Your web API key retrieved from retroachievements.org/settings.
  *
  * @param payload.username The user for which to retrieve the progress for.
  *
@@ -52,7 +51,7 @@ import type { GetUserProgressResponse, UserProgress } from "./models";
  * ```
  */
 export const getUserProgress = async (
-  authorization: AuthObject,
+  authorization: ApiAuthorization,
   payload: { username: string; gameIds: ID[] }
 ): Promise<UserProgress> => {
   const { username, gameIds } = payload;

--- a/src/user/getUserRecentAchievements.ts
+++ b/src/user/getUserRecentAchievements.ts
@@ -4,7 +4,7 @@ import {
   call,
   serializeProperties,
 } from "../utils/internal";
-import type { AuthObject } from "../utils/public";
+import type { ApiAuthorization } from "../utils/public";
 import type {
   GetUserRecentAchievementsResponse,
   UserRecentAchievement,
@@ -15,8 +15,7 @@ import type {
  * recently earned achievements, via their username. By default, it
  * fetches achievements earned in the last hour.
  *
- * @param authorization An object containing your username and webApiKey.
- * This can be constructed with `buildAuthorization()`.
+ * @param authorization Your web API key retrieved from retroachievements.org/settings.
  *
  * @param payload.username The user for which to retrieve the recent achievements for.
  *
@@ -54,7 +53,7 @@ import type {
  * ```
  */
 export const getUserRecentAchievements = async (
-  authorization: AuthObject,
+  authorization: ApiAuthorization,
   payload: { username: string; recentMinutes?: number }
 ): Promise<UserRecentAchievement[]> => {
   const { username, recentMinutes } = payload;

--- a/src/user/getUserRecentlyPlayedGames.ts
+++ b/src/user/getUserRecentlyPlayedGames.ts
@@ -4,7 +4,7 @@ import {
   call,
   serializeProperties,
 } from "../utils/internal";
-import type { AuthObject } from "../utils/public";
+import type { ApiAuthorization } from "../utils/public";
 import type {
   GetUserRecentlyPlayedGamesResponse,
   UserRecentlyPlayedGames,
@@ -14,8 +14,7 @@ import type {
  * A call to this function will retrieve a list of a target user's
  * recently played games, via their username.
  *
- * @param authorization An object containing your username and webApiKey.
- * This can be constructed with `buildAuthorization()`.
+ * @param authorization Your web API key retrieved from retroachievements.org/settings.
  *
  * @param payload.username The user for which to retrieve the summary for.
  *
@@ -54,7 +53,7 @@ import type {
  * ```
  */
 export const getUserRecentlyPlayedGames = async (
-  authorization: AuthObject,
+  authorization: ApiAuthorization,
   payload: { username: string; offset?: number; count?: number }
 ): Promise<UserRecentlyPlayedGames> => {
   const { username, offset, count } = payload;

--- a/src/user/getUserSummary.ts
+++ b/src/user/getUserSummary.ts
@@ -4,15 +4,14 @@ import {
   call,
   serializeProperties,
 } from "../utils/internal";
-import type { AuthObject } from "../utils/public";
+import type { ApiAuthorization } from "../utils/public";
 import type { GetUserSummaryResponse, UserSummary } from "./models";
 
 /**
  * A call to this function will retrieve summary information about
  * a given user, targeted by username.
  *
- * @param authorization An object containing your username and webApiKey.
- * This can be constructed with `buildAuthorization()`.
+ * @param authorization Your web API key retrieved from retroachievements.org/settings.
  *
  * @param payload.username The user for which to retrieve the summary for.
  *
@@ -33,7 +32,7 @@ import type { GetUserSummaryResponse, UserSummary } from "./models";
  * @returns An object containing summary metadata about a target user.
  */
 export const getUserSummary = async (
-  authorization: AuthObject,
+  authorization: ApiAuthorization,
   payload: {
     username: string;
     recentGamesCount?: number;

--- a/src/utils/internal/buildRequestUrl.test.ts
+++ b/src/utils/internal/buildRequestUrl.test.ts
@@ -28,7 +28,7 @@ describe("Util: buildRequestUrl", () => {
 
     // ASSERT
     expect(requestUrl).toEqual(
-      "https://retroachievements.org/API/myBazValue/API_GetConsoleIDs.php?z=TestUser&y=mockWebApiKey&limit=10&offset=2"
+      "https://retroachievements.org/API/myBazValue/API_GetConsoleIDs.php?y=mockWebApiKey&limit=10&offset=2"
     );
   });
 
@@ -45,7 +45,7 @@ describe("Util: buildRequestUrl", () => {
 
     // ASSERT
     expect(requestUrl).toEqual(
-      "https://retroachievements.org/API/:baz/API_GetConsoleIDs.php?z=TestUser&y=mockWebApiKey"
+      "https://retroachievements.org/API/:baz/API_GetConsoleIDs.php?y=mockWebApiKey"
     );
   });
 });

--- a/src/utils/internal/buildRequestUrl.ts
+++ b/src/utils/internal/buildRequestUrl.ts
@@ -1,9 +1,9 @@
-import type { AuthObject } from "../public/models";
+import type { ApiAuthorization } from "../public/models";
 
 export const buildRequestUrl = (
   baseUrl: string,
   endpointUrl: string,
-  authObject: AuthObject,
+  authorization: ApiAuthorization,
   args: Record<string, string | number> = {}
 ) => {
   const concatenated = `${baseUrl}/${endpointUrl}`;
@@ -11,11 +11,13 @@ export const buildRequestUrl = (
 
   let withArgs = withoutDoubleSlashes;
 
-  // `z` and `y` are expected query params from the RA API.
-  // Authentication is handled purely by query params.
+  // `y` is an always-required query param of the RA API.
+  // Authentication is handled purely by this query param.
   const queryParamValues: Record<string, string> = {
-    z: authObject.username,
-    y: authObject.webApiKey,
+    y:
+      typeof authorization === "string"
+        ? authorization
+        : authorization.webApiKey,
   };
 
   for (const [argKey, argValue] of Object.entries(args)) {

--- a/src/utils/public/buildAuthorization.ts
+++ b/src/utils/public/buildAuthorization.ts
@@ -1,4 +1,4 @@
-import type { AuthObject } from "./models";
+import type { ApiAuthorization } from "./models";
 
 /**
  * Accepts your RetroAchievements.org username and web API key. After
@@ -20,7 +20,9 @@ import type { AuthObject } from "./models";
  * });
  * ```
  */
-export const buildAuthorization = (options: AuthObject): AuthObject => {
+export const buildAuthorization = (
+  options: ApiAuthorization
+): ApiAuthorization => {
   if (!options.username || !options.webApiKey) {
     throw new Error(`
       buildAuthorization() requires an object containing a

--- a/src/utils/public/models/auth-object.model.ts
+++ b/src/utils/public/models/auth-object.model.ts
@@ -1,9 +1,13 @@
 /**
  * Each RetroAchievements API call is uniquely authenticated
- * using a username + API key combination. Your account's personal
- * Web API Key can be found on the Settings page.
+ * using a web API key. Your account's personal Web API Key can
+ * be found on the /settings page.
  */
-export interface AuthObject {
+
+/**
+ * @deprecated `username` is no longer required for web API calls. Pass a string containing just your webApiKey instead.
+ */
+interface LegacyAuthObject {
   /**
    * You or your app's exact username on the RetroAchievements.org website.
    * For example, https://retroachievements.org/user/Scott would have a value
@@ -18,3 +22,5 @@ export interface AuthObject {
    */
   webApiKey: string;
 }
+
+export type ApiAuthorization = string | LegacyAuthObject;


### PR DESCRIPTION
Resolves https://github.com/RetroAchievements/api-js/issues/105.

All functions can now be called without needing to build an authorization object, eg:

```ts
import { getGame } from "@retroachievements/api";

const webApiKey = "<your web API key>";

// This returns basic metadata about the game on this page:
// https://retroachievements.org/game/14402
const game = await getGame(webApiKey, { gameId: 14402 });
```