### PR TITLE
chore: use default packageManager, without explicit version.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,9 +7,6 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
-env:
-  PNPM_VERSION: 9.1.1
-
 jobs:
   build:
     name: Build, lint, and test on Node ${{ matrix.node }}
@@ -23,9 +20,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v3.0.0
-        with:
-          version: ${{ env.PNPM_VERSION }}
+        uses: pnpm/action-setup@v4
 
       - name: Use Node ${{ matrix.node }}
         uses: actions/setup-node@v4


### PR DESCRIPTION
[Optional when there is a packageManager field in the package.json](https://github.com/pnpm/action-setup/tree/v4/?tab=readme-ov-file#version)

---

there's no need to specify the pnpm version, now it defaults to the one used in the [packageManager](https://github.com/RetroAchievements/api-js/blob/9e3e9eaa22138301f4fe3a8ee6892f7fb719f80d/package.json#L99C4-L99C18)